### PR TITLE
support setting UUID with path param

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lightweight server to translate Grafana webhook to Feishu card.
 
 The program needs two environment variables:
 
-- `FEISHU_WEBHOOK`: The web hook URL to push Feishu notifications. Should be something like `https://open.feishu.cn/open-apis/bot/v2/hook/a21843-123-123-abc987`
+- `FEISHU_WEBHOOK_BASE`: (Optional) The web hook base URL to push Feishu notifications. Default is `https://open.feishu.cn/open-apis/bot/v2/hook`
 - `WEBHOOK_AUTH`: (Optional) The username and password. Should be something like `user:password`
 
 Here is an example docker compose file:
@@ -21,13 +21,17 @@ services:
     container_name: grafana-feishu
     restart: always
     environment:
-      - FEISHU_WEBHOOK=${FEISHU_WEBHOOK}
+      - FEISHU_WEBHOOK_BASE=${FEISHU_WEBHOOK_BASE}
       - WEBHOOK_AUTH=${WEBHOOK_AUTH}
 ```
 
 The exposed port is `2387`.
 
-After setting up the server, go to Grafana > "Alerting" > "Contact points", add a new contact point with integration as "Webhook". Fill in the URL (`http://grafana-feishu:2387` in this example) and credentials.
+After setting up the server, go to Grafana > "Alerting" > "Contact points", add a new contact point with integration as "Webhook". Fill in the URL and credentials. 
+
+The URL should be like `http://grafana-feishu:2387/{botUUID}`, where `{botUUID}` is the UUID of the bot you created in Feishu, i.e. the last part of the bot webhook URL.
+
+In the previous version, a whole bot URL (including the UUID) can be set with the environment variable `FEISHU_WEBHOOK`, and the bot UUID is not needed in Grafana. This is still supported.
 
 <img width="737" alt="Grafana config" src="https://user-images.githubusercontent.com/36528777/235901125-181eeb60-df6c-45ff-b550-7756a91c65d1.png">
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Lightweight server to translate Grafana webhook to Feishu card.
 
 The program needs two environment variables:
 
-- `FEISHU_WEBHOOK_BASE`: (Optional) The web hook base URL to push Feishu notifications. Default is `https://open.feishu.cn/open-apis/bot/v2/hook`
+- `FEISHU_WEBHOOK`: (Optional) The web hook URL to push Feishu notifications. Should be something like `https://open.feishu.cn/open-apis/bot/v2/hook/a21843-123-123-abc987`
+- `FEISHU_WEBHOOK_BASE`: (Optional, has no effect if `FEISHU_WEBHOOK` is set) Something like `https://open.feishu.cn/open-apis/bot/v2/hook` (default).
+- `FEISHU_WEBHOOK_UUID`: (Optional, has no effect if `FEISHU_WEBHOOK` is set) The bot UUID, something like `a21843-123-123-abc987`.
+If the bot UUID is not specified, it should be provided in the path. See below for detail.
 - `WEBHOOK_AUTH`: (Optional) The username and password. Should be something like `user:password`
 
 Here is an example docker compose file:
@@ -21,17 +24,18 @@ services:
     container_name: grafana-feishu
     restart: always
     environment:
-      - FEISHU_WEBHOOK_BASE=${FEISHU_WEBHOOK_BASE}
       - WEBHOOK_AUTH=${WEBHOOK_AUTH}
+      - FEISHU_WEBHOOK=${FEISHU_WEBHOOK}
+      # Or, instead of FEISHU_WEBHOOK:
+      # - FEISHU_WEBHOOK_BASE=${FEISHU_WEBHOOK_BASE}
+      # - FEISHU_WEBHOOK_UUID=${FEISHU_WEBHOOK_UUID}
 ```
 
 The exposed port is `2387`.
 
 After setting up the server, go to Grafana > "Alerting" > "Contact points", add a new contact point with integration as "Webhook". Fill in the URL and credentials. 
 
-The URL should be like `http://grafana-feishu:2387/{botUUID}`, where `{botUUID}` is the UUID of the bot you created in Feishu, i.e. the last part of the bot webhook URL.
-
-In the previous version, a whole bot URL (including the UUID) can be set with the environment variable `FEISHU_WEBHOOK`, and the bot UUID is not needed in Grafana. This is still supported.
+If the bot UUID is provided in `FEISHU_WEBHOOK` or `FEISHU_WEBHOOK_UUID` is set, the URL should be `http://grafana-feishu:2387`. Otherwise, the URL should be `http://grafana-feishu:2387/{botUUID}`, where `{botUUID}` is the UUID of the bot you created in Feishu, i.e. the last part of the bot webhook URL.
 
 <img width="737" alt="Grafana config" src="https://user-images.githubusercontent.com/36528777/235901125-181eeb60-df6c-45ff-b550-7756a91c65d1.png">
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/AllanChain/grafana-feishu
 
 go 1.20
 
+require github.com/gofiber/fiber/v2 v2.44.0
+
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/gofiber/fiber/v2 v2.44.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
Now user can set grafana webhook URL to something like 
`http://grafana-feishu:2387/11223344-abcd-abcd-abcd-11223344`

The bot UUID is extracted from path param. Also fully compatible with old environments. 
